### PR TITLE
Feature/bliss 226/update ios sdk v6

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -43,6 +43,6 @@
     <pods-config ios-min-version="9.0" use-frameworks="true"/>
     <source-file src="src/ios/UsabillaCordova.swift" />
     <source-file src="src/ios/FeedbackController.swift" />
-    <pod name="Usabilla" version="5.0.2" />
+    <pod name="Usabilla" />
   </platform>
 </plugin>


### PR DESCRIPTION
For the iOS we point to the pod version, that Cordova should use.
The SDK uses iOS 9.4 as least version, this is also updated