### PR TITLE
added onNewIntent override method to handle it in cordova plugins

### DIFF
--- a/src/android/activity/MainActivity.java
+++ b/src/android/activity/MainActivity.java
@@ -49,6 +49,12 @@ public class MainActivity extends AppCompatActivity {
         super.onResume();
         currentFragment.onResume();
     }
+	
+	@Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        currentFragment.onNewIntent(intent);
+    }
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {


### PR DESCRIPTION
This event is needed for deeplinks handling. Since you replace the MainActivity, I can not get it in the deeplinks plugin anymore. I would appreciate it if you included this small change in the next release, otherwise, I have to maintain it manually.